### PR TITLE
Remove unsupported .editorconfig MSBuild config

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -35,9 +35,6 @@ indent_size = 4
 trim_trailing_whitespace = true
 guidelines = 80, 100, 120
 
-# No Warn
-dotnet_diagnostic.MSB3270.severity = none
-
 # Warnings as Errors
 dotnet_diagnostic.NU1605.severity = error
 


### PR DESCRIPTION
### Context

MSBuild is not suporting `.editorconfig` configurations. Such are currently ignored with no effect.
In the future MSBuild might use `.editorcinfig` for configuring new types of checks. And to prevent the confusion, it might flag attempts to use it for traditional MSBxxxx codes. So the line being removed might lead to a warning in the future.